### PR TITLE
#7 Removed Open Api Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ This curated list covers the best resources, tutorials, and community content re
 - [CodeRabbit Startup Program](https://www.coderabbit.ai/blog/coderabbit-startup-program) - Special program for startups.
 - [AI Code Reviewer Examples](https://www.coderabbit.ai/blog/how-to-use-an-ai-code-reviewer-on-github-in-4-examples) - Four practical examples of using CodeRabbit.
 
-## API Reference
-
-- [OpenAPI Documentation](https://api.coderabbit.ai/api/swagger/) - Complete Swagger documentation for CodeRabbit's REST API endpoints.
-
 ## Configuration Examples
 
 ### Enterprise Configuration Example


### PR DESCRIPTION
### **Description**
The OpenAPI documentation link provided in the `README.md` file is currently broken or inaccessible. When users click the link, they are either redirected to a missing page or encounter an error.  

This impacts contributors and users who rely on the documentation to understand and interact with the API.

---

### **What I Did**
- Verified that the OpenAPI documentation link in `README.md` was not working.  
- Confirmed that there is no publicly available or accessible OpenAPI documentation URL.  
- Removed the invalid OpenAPI link from the `README.md` file to prevent user confusion.

---

### **Proposed Fix / Next Steps**
- Host or generate the OpenAPI documentation on a public endpoint (e.g., Swagger UI, ReDoc, or GitHub Pages).  
- Once available, update the `README.md` file with the correct and verified documentation link.  
- Optionally, include instructions for generating or accessing the OpenAPI documentation locally (for example, via `npm run openapi`).

---

### **Impact**
- Users and contributors currently cannot access the API documentation from the `README.md`.  
- May cause onboarding friction for new developers or users exploring the project.