### PR TITLE
Add custom pre-merge checks

### DIFF
--- a/configs/pre-mergechecks/.coderabbit-data-privacy.yaml
+++ b/configs/pre-mergechecks/.coderabbit-data-privacy.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "Pipeline Integrity Validation"
+        mode: "warning"
+        instructions: >-
+          When new data pipelines are introduced to the repository, verify that the pipeline includes data quality validation. Check for any of the following indicators: a dedicated data quality checks configuration file, use of a data quality framework library in the pipeline's dependencies, data quality assertion calls in pipeline code, or a sibling data quality pipeline in the same directory. If none are found, warn that the new pipeline should include data quality checks and point to existing examples in the codebase. Pass when the pipeline includes any data quality validation, or when the PR is modifying an existing pipeline rather than introducing a new one.
+
+      - name: "Deployment-Ready Config Verification"
+        mode: "error"
+        instructions: >-
+          When production configuration files are modified, review all new or modified values in those files. Fail if any value contains a placeholder such as `TBD`, `PLACEHOLDER`, `TODO`, `REPLACE_ME`, or an empty string where a real value is required. Fail if required identifiers (workflow IDs, service endpoints, ARNs, connection strings) are not populated with real values. Fail if configuration key names are inconsistent across environments (the same logical setting using different key names in staging vs. production). Pass only when all production configuration values are real, consistent, and deployment-ready.

--- a/configs/pre-mergechecks/.coderabbit-infrastructure.yaml
+++ b/configs/pre-mergechecks/.coderabbit-infrastructure.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "IaC Template Version Integrity"
+        mode: "error"
+        instructions: >-
+          When infrastructure-as-code templates (CloudFormation, Terraform modules, Chef cookbooks, Helm charts, Ansible roles) are modified, and functional sections of an IaC template are changed (resources, parameters, outputs, recipes, tasks, or equivalent—not comments or metadata-only fields), the template's version identifier must be incremented. Verify that the version field exists in the modified template and that its value has changed compared to the base branch. Fail if functional changes are present but the version is unchanged. Pass when the version is incremented for any functional change, or when only comments or documentation are modified.
+
+      - name: "Chart Dependency Lock Consistency"
+        mode: "warning"
+        instructions: >-
+          When Helm Chart.yaml files are modified and a `Chart.yaml` dependency version is changed, verify that the corresponding `Chart.lock` file is also updated in the same PR. If no `Chart.lock` file exists, skip this check. A stale lock file means declared dependencies and locked dependencies are out of sync, producing unpredictable results during `helm install` or `helm upgrade`. Instruct the author to run `helm dependency update <chart-directory>` and commit the resulting lock file. Pass when `Chart.yaml` and `Chart.lock` reflect the same dependency versions.
+
+      - name: "User Interaction Tracking Coverage"
+        mode: "warning"
+        instructions: >-
+          Review new user-facing features, screens, and interactive flows for the presence of analytics event instrumentation. Flag any new screen, modal, sheet, or multi-step flow with no analytics capture calls. Flag analytics events fired with empty or minimal payloads lacking contextual metadata useful for analysis (entity IDs, flow step, error codes, action type). Flag new event names used in capture calls that are not registered in the project's analytics event type definitions. Pass when new user-facing features include instrumentation, or when the PR description explicitly documents that instrumentation will be added in a follow-up with a linked ticket.
+
+      - name: "UI Accessibility Regression Check"
+        mode: "warning"
+        instructions: >-
+          When UI component files are modified, review new and modified UI components for clear accessibility regressions. Flag decorative images (icons, backgrounds, logos) that lack an attribute marking them as presentational (e.g., `aria-hidden`, `alt=""`). Flag interactive elements (buttons, links, inputs) that lack an accessible name—either a visible label, `aria-label`, or `aria-labelledby` reference. Flag heading elements used out of document order (e.g., `h3` immediately following `h1` with no `h2`). Flag duplicate `id` attributes within the same document. Do not flag minor styling changes or content-only edits. Pass when no clear accessibility regressions are introduced.
+
+      - name: "Debug Output Removal Enforcement"
+        mode: "error"
+        instructions: >-
+          When application source files are modified, review all modified application source files (e.g., in `src/`, `lib/`, `app/`, or `packages/*/src/`) for debug output statements such as `console.log`, `console.error`, `console.warn`, `print`, or equivalent. Fail if any such statement is found in production-destined source code. Exclude test files, fixture files, generated code, build artifacts, and local tooling scripts. Pass when no debug console statements are present in application source.

--- a/configs/pre-mergechecks/.coderabbit-performance.yaml
+++ b/configs/pre-mergechecks/.coderabbit-performance.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "Runtime Efficiency and Scaling Review"
+        mode: "error"
+        instructions: >-
+          Review changed code for material performance regressions. Flag O(n²) or worse behavior in any path that processes non-trivially sized input, including request handlers, background jobs, rendering paths, and collection iteration. Flag N+1 query patterns—database or external service calls inside a loop that should be batched, joined, or preloaded. Flag repeated recomputation of deterministic values inside loops where caching, memoization, or pre-computation outside the loop would eliminate redundant work. Flag inefficient data structure choices such as linear-search arrays for membership checks where a hash set is appropriate. Flag unbounded data accumulation, missing pagination, or caches without eviction. Flag expensive synchronous work (compression, hashing, template rendering) in hot paths where it should be deferred or sampled. Report only issues that could materially degrade latency, throughput, or resource usage at realistic input sizes—ignore micro-optimizations and speculative concerns.

--- a/configs/pre-mergechecks/.coderabbit-pr-hygiene.yaml
+++ b/configs/pre-mergechecks/.coderabbit-pr-hygiene.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "Backward Compatibility Impact Disclosure"
+        mode: "error"
+        instructions: >-
+          Review the PR for breaking changes to public interfaces: removed or renamed exported functions, types, or components; required fields added to existing request or response models (callers without the new field will fail); narrowed parameter types; changed default values that alter existing behavior; removed environment variables or configuration keys; changed event or message schemas. If any breaking change is detected, verify that: the PR description includes a "Breaking Changes" section listing each change with a migration path; the changelog is updated under an appropriate heading; and the version bump (if applicable) reflects a major version increment. Fail if breaking changes exist without documentation. Pass when all breaking changes are explicitly documented and versioned.
+
+      - name: "Architectural Decision Justification"
+        mode: "warning"
+        instructions: >-
+          When a PR introduces a significant change—a new service, major architectural shift, new data model, or a change that affects multiple teams—verify that the PR description references a design or requirements document. If no document is linked and the change is material, verify that the PR description includes a clear written justification for why a design document is not required. Flag any significant change with neither a design document link nor an exemption rationale. Pass when a design document is referenced or the exemption is explicitly documented.
+
+      - name: "Docs-to-Code Alignment"
+        mode: "error"
+        instructions: >-
+          When code changes make existing documentation stale—by changing CLI commands, configuration options, public API signatures, or user-facing behavior—verify that the relevant documentation files are updated in the same PR. Fail if documentation is demonstrably out of date with the code after this change merges. Pass when either no documentation is affected or all affected documentation has been updated.

--- a/configs/pre-mergechecks/.coderabbit-quality.yaml
+++ b/configs/pre-mergechecks/.coderabbit-quality.yaml
@@ -16,8 +16,7 @@ reviews:
       - name: "Direct Module Import Enforcement"
         mode: "error"
         instructions: >-
-          When TypeScript or JavaScript files are modified, review all new import statements in `.ts` and `.tsx` files. Fail if any import pulls from a barrel re-export file that aggregates multiple unrelated modules (e.g., an `index.ts` re-exporting dozens of unrelated components or hooks). Third-party package imports are always allowed. For local imports, flag multi-named imports from a single local path that aggregates unrelated modules and require them to be replaced with direct module paths. Fail if any new `index.ts` re-exports modules from multiple unrelated sibling folders. Pass when all local imports use direct paths to the specific module being consumed.
-
+          When TypeScript or JavaScript files are modified, review all new import statements in `.ts`, `.tsx`, `.js`, and `.jsx` files. Fail if any import pulls from a barrel re-export file that aggregates multiple unrelated modules (e.g., an `index.ts` re-exporting dozens of unrelated components or hooks). Third-party package imports are always allowed. For local imports, flag multi-named imports from a single local path that aggregates unrelated modules and require them to be replaced with direct module paths. Fail if any new `index.ts` re-exports modules from multiple unrelated sibling folders. Pass when all local imports use direct paths to the specific module being consumed.
       - name: "Failure Path Robustness Review"
         mode: "warning"
         instructions: >-

--- a/configs/pre-mergechecks/.coderabbit-quality.yaml
+++ b/configs/pre-mergechecks/.coderabbit-quality.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "Module Cohesion and Naming Clarity"
+        mode: "warning"
+        instructions: >-
+          Review packages, classes, functions, and methods for adherence to the Single Responsibility Principle. Flag any module or package that accumulates unrelated concerns. Flag classes or structs with more than approximately seven top-level fields as candidates for decomposition. Flag functions that operate across multiple levels of abstraction or handle more than one distinct concern. Flag generic, context-free names such as `Manager`, `Handler`, `Util`, `Process`, or `Do`—names should clearly communicate a single specific concept relative to their context. Flag methods with more than four or five parameters, which often signals that a parameter object or further abstraction is warranted. Pass when each unit has one clear purpose and names communicate that purpose unambiguously.
+
+      - name: "Public API Contract Consistency"
+        mode: "warning"
+        instructions: >-
+          Review any changes to exported or public method and function signatures. Flag additions, removals, or reordering of parameters; type changes (including adding or removing optionality); return type changes; and visibility changes (e.g., making a public method private). When a signature change is detected, verify that all call sites have been updated in the same PR. Also flag file renames or directory moves that change import paths without updating all consumer imports. Pass when no caller references an outdated signature or stale import path.
+
+      - name: "Direct Module Import Enforcement"
+        mode: "error"
+        instructions: >-
+          When TypeScript or JavaScript files are modified, review all new import statements in `.ts` and `.tsx` files. Fail if any import pulls from a barrel re-export file that aggregates multiple unrelated modules (e.g., an `index.ts` re-exporting dozens of unrelated components or hooks). Third-party package imports are always allowed. For local imports, flag multi-named imports from a single local path that aggregates unrelated modules and require them to be replaced with direct module paths. Fail if any new `index.ts` re-exports modules from multiple unrelated sibling folders. Pass when all local imports use direct paths to the specific module being consumed.
+
+      - name: "Failure Path Robustness Review"
+        mode: "warning"
+        instructions: >-
+          Review error handling patterns in new and modified code. Flag returned errors silently discarded (e.g., assigned to `_`) without an inline justification. Flag error matching based on string comparison of error messages—prefer stable error codes or typed error classes. Flag accesses to `error.message` without null or optional-chaining protection. Flag catch blocks that log only a message string instead of the full error object or stack trace. Flag top-level async entry points (bootstrap scripts, job runners) that lack a `.catch()` or `try/catch` that logs the error and exits the process with a non-zero code. Pass when errors are handled with stable codes, logged with full context, and entry points cannot swallow failures silently.
+
+      - name: "Commit Message Format Compliance"
+        mode: "warning"
+        instructions: >-
+          Review all commit messages in the PR for Conventional Commits compliance. Each message must start with a type (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `perf`, or similar), followed by an optional parenthetical scope, an optional `!` to signal a breaking change, a colon, a space, and a short description. Use `feat` for new features and `fix` for bug fixes. If a scope is provided, the commit must only affect code within that scope. A longer body may follow the short description, separated by a blank line. Flag any commit message that does not conform to this structure.

--- a/configs/pre-mergechecks/.coderabbit-security.yaml
+++ b/configs/pre-mergechecks/.coderabbit-security.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "Query Parameterization Enforcement"
+        mode: "error"
+        instructions: >-
+          Review all new or modified database query construction. Fail if any query is built by concatenating or interpolating user-supplied input directly into a SQL string. Use parameterized queries or prepared statements with placeholders for all external values. Reuse prepared statements for repeated queries rather than rebuilding them per call. Flag any string-building approach to query construction and require it to be replaced with parameterized equivalents before merging.
+
+      - name: "Sensitive Output Leak Prevention"
+        mode: "error"
+        instructions: >-
+          Review all new or modified log statements and direct output writes (`logger.*`, `console.log`, `print`, `fmt.Println`, `System.out.println`, and equivalent). Fail if any log message includes passwords, secrets, or API keys; PII such as names, SSNs, dates of birth, email addresses, or phone numbers; or payment card data. Fail for any log statement using string concatenation or interpolation to build the message instead of parameterized structured logging. Fail if exceptions or stack traces are logged at INFO or WARN level (they must use ERROR or above). Fail if normal successful operations are logged at ERROR level. If sensitive data must appear in any observable output, it must be masked before logging. Pass when logs are structured, use appropriate severity levels, and contain no sensitive data in plaintext.
+
+      - name: "Top Vulnerability Pattern Audit"
+        mode: "warning"
+        instructions: >-
+          Review all changed code against the OWASP Top 10 for Web (2021) and API Security (2023). Flag broken access control (missing authorization checks, insecure direct object references, privilege escalation paths); cryptographic failures (hardcoded secrets, weak algorithms such as MD5/SHA1/DES, unencrypted sensitive data in transit or at rest); injection vulnerabilities (SQL, NoSQL, OS command, or expression-language injection via unsanitized input); security misconfiguration (default credentials, verbose error messages exposing stack traces, permissive IAM policies); vulnerable or outdated components with published CVEs; identification and authentication failures (weak session management, improper token validation); and SSRF (user-controlled URLs passed to server-side HTTP requests without allowlisting). For API endpoints, additionally flag broken object-level authorization, unrestricted resource consumption without rate limiting or pagination, and over-fetching of sensitive fields in responses. Post each finding as a comment on the affected line with a brief remediation note.
+
+      - name: "Dependency Risk Assessment"
+        mode: "warning"
+        instructions: >-
+          When dependency manifests (package.json, pom.xml, requirements.txt, go.mod, Gemfile, etc.) are modified, review newly added or upgraded third-party libraries. Flag any dependency with known security vulnerabilities in public advisory databases. Flag libraries with non-permissive licenses (e.g., AGPL, GPL) when the project requires permissive licenses (e.g., MIT, Apache 2.0). Pay particular attention to libraries that handle authentication, payments, healthcare data, or cryptography. Require explicit justification in the PR description for any dependency that introduces significant legal or security risk.
+
+      - name: "Personal Data Exposure Guard"
+        mode: "error"
+        instructions: >-
+          Review all changed code for improper handling of Personally Identifiable Information (PII) and other sensitive personal data (including Protected Health Information in healthcare contexts). Fail if PII fields (names, email addresses, phone numbers, dates of birth, government IDs, addresses, income, medical record numbers, diagnoses) are transmitted to logs, analytics pipelines, third-party services, or API responses without authorization. Verify that database queries select only the minimum fields necessary for the operation. Flag API responses that use denylists rather than allowlists to filter sensitive fields—allowlists are required to prevent accidental over-exposure. Verify that data masking is applied server-side, never delegated to the client. Fail if any data pathway could expose User A's PII to User B.

--- a/configs/pre-mergechecks/.coderabbit-testing.yaml
+++ b/configs/pre-mergechecks/.coderabbit-testing.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  pre_merge_checks:
+    custom_checks:
+      - name: "New Logic Test Adequacy"
+        mode: "warning"
+        instructions: >-
+          Review the PR for new or modified source code that lacks corresponding test coverage. Flag new functions, methods, and classes that have no unit tests—especially pure functions where testing is straightforward. Flag bug fixes without a regression test that fails without the fix. Flag new error-throwing paths that have no test asserting the error is raised correctly. Flag test factories or fixtures that were not updated when the corresponding entity gained new required fields. Do not flag trivial changes (renaming, formatting, comments), generated code, or refactors fully covered by existing tests. Pass when new logic has proportionate test coverage across happy paths, error paths, and edge cases.
+
+      - name: "Test Hygiene and Isolation"
+        mode: "warning"
+        instructions: >-
+          Review new and modified test code for structural quality. Flag tests that assert multiple unrelated behaviors in a single test case—each test should validate one specific behavior. Flag tests that create resources without a corresponding teardown, especially resources with global scope. Flag async operations or external interactions that lack explicit timeout bounds. Flag assertions that have no descriptive failure message—include a message so failures are self-explanatory without reading source code. Flag tests that duplicate logic already covered by lower-level unit tests; high-level tests should verify calls and outcomes, not re-implement algorithm assertions. Pass when tests are focused, self-cleaning, bounded, and produce clear failure messages.
+
+      - name: "Validation Evidence for Impactful PRs"
+        mode: "warning"
+        instructions: >-
+          When a PR introduces significant changes (new features, breaking changes, substantial refactoring, or algorithmic modifications), verify that the PR description includes evidence of testing. For changes that could affect numerical accuracy or convergence, require before-and-after results demonstrating no regression. For performance-affecting changes, require before-and-after benchmark numbers along with the configuration and context in which they were measured. Pass when changes are minor or when test evidence is documented. Flag when material changes are introduced with no validation evidence in the description.


### PR DESCRIPTION
Added a list of custom pre-merge checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pre-merge review checks across multiple domains—data privacy, infrastructure, performance, PR hygiene, code quality, security, and testing—to strengthen the review process, surface regressions earlier, and enforce production readiness and consistency before merge.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/awesome-coderabbit/pull/20)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->