### PR TITLE
Add custom finishing-touch recipes

### DIFF
--- a/configs/custom-recipes/.coderabbit-a11y.yaml
+++ b/configs/custom-recipes/.coderabbit-a11y.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "associate form labels"
+        instructions: |
+          For newly added or modified form controls in this PR, ensure each
+          visible input, textarea, and select has an accessible name through
+          a correctly associated <label>, wrapping label, aria-label, or
+          aria-labelledby, whichever matches the existing component pattern.
+          If using htmlFor, add a stable id only when missing and follow the
+          repo's naming pattern. Add aria-describedby when nearby help text
+          or error text is rendered. Do not add redundant labels to hidden
+          inputs or controls already correctly labeled through grouped
+          patterns such as fieldset and legend.

--- a/configs/custom-recipes/.coderabbit-api.yaml
+++ b/configs/custom-recipes/.coderabbit-api.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "regenerate openapi/graphql schema"
+        instructions: |
+          When this PR changes route handlers, request or response contracts,
+          GraphQL schema inputs, resolvers, or other API-surface definitions
+          that normally drive generated specs, run the repository's existing
+          OpenAPI, GraphQL, or contract-generation command and commit the
+          generated output. Do not hand-edit generated schema or spec files.
+          If the spec is generated in another repository or pipeline, update
+          the source of truth here and report the handoff rather than
+          editing downstream generated artifacts manually. If no generation
+          command can be found, report that the repository is missing an
+          explicit schema regeneration workflow.

--- a/configs/custom-recipes/.coderabbit-cleanup.yaml
+++ b/configs/custom-recipes/.coderabbit-cleanup.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "cleanup stale imports"
+        instructions: |
+          Remove unused imports only in files changed by this PR. Preserve
+          type-only imports, side-effect imports, CSS imports, and any import
+          still required by the project's compiler, typechecker, linter, or
+          build tooling. Do not reorder, regroup, or reformat imports. Delete
+          only imports that the repo's existing tooling proves are unused. If
+          no authoritative unused-import signal exists for a file, leave it
+          unchanged.

--- a/configs/custom-recipes/.coderabbit-db.yaml
+++ b/configs/custom-recipes/.coderabbit-db.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "regenerate orm types"
+        instructions: |
+          When this PR changes database schema through migrations or schema
+          files, run the repository's existing ORM or query type generation
+          command, such as prisma generate, sqlc generate, or the
+          repo-defined equivalent, and commit only the generated artifacts
+          that are already tracked or normally committed in this repository.
+          Do not hand-edit generated files. If no authoritative generation
+          command is defined, report that regeneration could not be
+          performed.

--- a/configs/custom-recipes/.coderabbit-docs.yaml
+++ b/configs/custom-recipes/.coderabbit-docs.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "document new public APIs"
+        instructions: |
+          For functions, classes, and types newly exported by this PR from a
+          package's public surface, add or improve docstrings following the
+          repository's existing documentation style. Cover purpose,
+          parameters, return value when applicable, and one short usage
+          example. Skip internal-only exports, local helpers, and symbols not
+          exposed through the package's public entry points or declared
+          export barrels. If the repo has no established inline API-doc
+          convention, report the missing documentation rather than inventing
+          a new style.

--- a/configs/custom-recipes/.coderabbit-env.yaml
+++ b/configs/custom-recipes/.coderabbit-env.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "propagate new env var"
+        instructions: |
+          When this PR introduces a new environment variable read such as
+          process.env.X or the language-equivalent pattern, propagate X to the
+          repository's existing configuration surfaces where applicable:
+          .env.example, config schema or validator, documented env tables,
+          compose or deployment manifests, and CI config or secret lists that
+          already exist in the repo. Match the repo's existing naming and
+          classification conventions. If X is sensitive, add only a
+          placeholder and wire it through existing secret/config surfaces
+          without exposing a value. Use a placeholder value with a short
+          comment describing the var's purpose where the existing files
+          include comments. Do not create new infra files. Do not edit
+          generated documentation or derived config artifacts by hand; update
+          the source of truth or report the missing propagation path.

--- a/configs/custom-recipes/.coderabbit-imports.yaml
+++ b/configs/custom-recipes/.coderabbit-imports.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "update import paths after file moves"
+        instructions: |
+          When files are moved or renamed in this PR, update broken import
+          and export specifiers that reference the old paths across changed
+          files and directly affected dependents. Prefer the repository's
+          existing path alias conventions when the new location is normally
+          imported that way; otherwise preserve the prevailing local import
+          style. Update re-export barrels when needed. Do not rewrite
+          unrelated paths, plain strings, or documentation text unless they
+          are clearly part of a moved-code reference that this PR already
+          touches.

--- a/configs/custom-recipes/.coderabbit-security.yaml
+++ b/configs/custom-recipes/.coderabbit-security.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "scrub hardcoded secrets"
+        instructions: |
+          Detect high-confidence hardcoded secrets introduced or modified in
+          this PR, including API keys, tokens, signing keys, passwords, and
+          connection strings. Replace each real secret with the repository's
+          normal environment/config lookup pattern, using names that match
+          existing conventions. Add the variable to .env.example with a
+          placeholder, and update existing env documentation if the repo
+          maintains it. Never preserve or re-emit the real secret value
+          anywhere. Skip obvious placeholders, test fixtures, mock
+          credentials, and documentation examples (such as "YOUR_API_KEY",
+          "changeme", "test-token", or values inside README/docs snippets)
+          unless they appear to be real credentials. If confidence is not
+          high, report the finding instead of rewriting. In the PR summary,
+          note that any real secret already committed must be revoked and
+          rotated outside the PR.

--- a/configs/custom-recipes/.coderabbit-testing.yaml
+++ b/configs/custom-recipes/.coderabbit-testing.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  finishing_touches:
+    custom:
+      - name: "sync tests with signature changes"
+        instructions: |
+          When a function changed in this PR has a signature change in
+          parameters or return shape, update directly affected test files so
+          their call sites, mocks, fixtures, expected values, and type
+          assertions match the new signature. Preserve each test's original
+          intent and behavioral assertion. Do not broaden test edits beyond
+          directly affected tests. Do not rewrite assertions to fit a
+          semantic behavior change unless the production diff clearly shows
+          the behavior is unchanged and only the interface changed; otherwise
+          report that the tests need human review.


### PR DESCRIPTION
Adds a `configs/custom-recipes/` directory with 9 Custom Finishing Touch recipes for CodeRabbit, organized by category.

Each recipe is narrowly scoped, follows the project's existing conventions, and reports gaps rather than guessing when a clear signal is missing.

## Recipes
- `cleanup stale imports`
- `sync tests with signature changes`
- `propagate new env var`
- `document new public APIs`
- `scrub hardcoded secrets`
- `associate form labels`
- `regenerate orm types`
- `update import paths after file moves`
- `regenerate openapi/graphql schema`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit review recipe configurations enabling enhanced automated code quality checks across accessibility standards, API contracts, import management, database schema changes, documentation requirements, environment variable propagation, hardcoded secrets detection, and test file updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/awesome-coderabbit/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->