### PR TITLE
Add starter CodeRabbit configs

### DIFF
--- a/configs/starter/barebones.coderabbit.yaml
+++ b/configs/starter/barebones.coderabbit.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+inheritance: true
+
+reviews:
+  disable_cache: true
+  high_level_summary: false
+  review_status: false
+  changed_files_summary: false
+  suggested_reviewers: false
+  estimate_code_review_effort: false
+  in_progress_fortune: false
+  poem: false
+  path_instructions:
+    - path: '**/*'
+      instructions: >
+        - Only comment on issues that would block merging — ignore minor or stylistic concerns.
+
+        - Restrict feedback to errors, security risks, or functionality-breaking problems.
+
+        - Do not post comments on code style, formatting, or non-critical
+          improvements.
+        - Keep reviews short: flag only issues that make the PR unsafe to merge.
+
+        - Limit review comments to 3–5 items maximum, unless additional blockers
+          exist.
+        - Group similar issues into a single comment instead of posting multiple
+          notes.
+        - Skip repetition — if a pattern repeats, mention it once at a summary
+          level only.
+        - Do not add general suggestions, focus strictly on merge-blocking
+          concerns.
+        - If there are no critical problems, respond with minimal approval
+          (e.g., 'Looks good'). Do not add additional review.
+        - Avoid line-by-line commentary unless it highlights a critical bug or security hole.
+
+        - Highlight only issues that could cause runtime errors, data loss, or severe
+        maintainability issues.
+
+        - Ignore minor optimization opportunities — focus solely on correctness and safety.
+
+        - Provide a top-level summary of critical blockers rather than detailed per-line notes.
+
+        - Comment only when the issue must be resolved before merge — otherwise remain silent.
+
+        - When in doubt, err on the side of fewer comments — brevity and
+          blocking issues only.
+        - Avoid posting any refactoring issues
+  auto_review:
+    auto_incremental_review: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
+    title:
+      mode: 'off'
+    description:
+      mode: 'off'
+    issue_assessment:
+      mode: 'off'
+chat:
+  art: false

--- a/configs/starter/initial.coderabbit.yaml
+++ b/configs/starter/initial.coderabbit.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+tone_instructions: Prefer concise responses (high information density, low fluff)
+inheritance: true
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  disable_cache: true
+  collapse_walkthrough: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+
+  high_level_summary: true
+  high_level_summary_instructions: "Give a brief description of the changes in 50 words or less."
+  high_level_summary_in_walkthrough: false
+
+  path_instructions:
+    - path: '**/*'
+      instructions: >
+        - Ignore minor or stylistic concerns.
+        - Restrict feedback to errors, security risks, or functionality-breaking problems.
+        - Do not post comments on code style, formatting, or non-critical
+          improvements.
+        - Keep reviews short: flag only issues that make the PR unsafe to merge.
+        - Limit review comments to 3–5 items maximum, unless additional blockers
+          exist.
+        - Group similar issues into a single comment instead of posting multiple
+          notes.
+        - Skip repetition — if a pattern repeats, mention it once at a summary
+          level only.
+        - Do not add general suggestions, focus strictly on merge-blocking
+          concerns.
+        - If there are no critical problems, respond with minimal approval
+          (e.g., 'Looks good'). Do not add additional review.
+        - Avoid line-by-line commentary unless it highlights a critical bug or security hole.
+        - Highlight only issues that could cause runtime errors, data loss, or severe
+        maintainability issues.
+        - Ignore minor optimization opportunities — focus solely on correctness and safety.
+        - Provide a top-level summary of critical blockers rather than detailed per-line notes.
+        - Comment only when the issue must be resolved before merge — otherwise remain silent.
+        - When in doubt, err on the side of fewer comments — brevity and
+          blocking issues only.
+  auto_review:
+    auto_incremental_review: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
+    title:
+      mode: 'off'
+    description:
+      mode: 'off'
+    issue_assessment:
+      mode: 'off'
+
+knowledge_base:
+  issues:
+    scope: local
+  pull_requests:
+    scope: local

--- a/configs/starter/quiet.coderabbit.yaml
+++ b/configs/starter/quiet.coderabbit.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+inheritance: true
+
+reviews:
+  disable_cache: true
+  collapse_walkthrough: false
+  changed_files_summary: false
+  suggested_reviewers: false
+  estimate_code_review_effort: false
+  in_progress_fortune: false
+  poem: false
+  path_instructions:
+    - path: '**/*'
+      instructions: >
+        - Ignore minor or stylistic concerns.
+        - Restrict feedback to errors, security risks, or functionality-breaking problems.
+        - Do not post comments on code style, formatting, or non-critical
+          improvements.
+        - Keep reviews short: flag only issues that make the PR unsafe to merge.
+        - Limit review comments to 3–5 items maximum, unless additional blockers
+          exist.
+        - Group similar issues into a single comment instead of posting multiple
+          notes.
+        - Skip repetition — if a pattern repeats, mention it once at a summary
+          level only.
+        - Do not add general suggestions, focus strictly on merge-blocking
+          concerns.
+        - If there are no critical problems, respond with minimal approval
+          (e.g., 'Looks good'). Do not add additional review.
+        - Avoid line-by-line commentary unless it highlights a critical bug or security hole.
+        - Highlight only issues that could cause runtime errors, data loss, or severe
+        maintainability issues.
+        - Ignore minor optimization opportunities — focus solely on correctness and safety.
+        - Provide a top-level summary of critical blockers rather than detailed per-line notes.
+        - Comment only when the issue must be resolved before merge — otherwise remain silent.
+        - When in doubt, err on the side of fewer comments — brevity and
+          blocking issues only.
+        - Avoid posting any refactoring issues
+  auto_review:
+    auto_incremental_review: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
+    title:
+      mode: 'off'
+    description:
+      mode: 'off'
+    issue_assessment:
+      mode: 'off'

--- a/configs/starter/sample.coderabbit.yaml
+++ b/configs/starter/sample.coderabbit.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+tone_instructions: Prefer concise responses (high information density, low fluff)
+inheritance: true
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  disable_cache: true
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: true
+  estimate_code_review_effort: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: true
+
+  high_level_summary: true
+  high_level_summary_instructions: "Give a brief description of the changes in 50 words or less."
+  high_level_summary_in_walkthrough: false
+
+  path_instructions:
+    - path: '**/*'
+      instructions: >
+        - Keep reviews short: flag only issues that make the PR unsafe to merge.
+        - Group similar issues into a single comment instead of posting multiple
+          notes.
+        - Skip repetition — if a pattern repeats, mention it once at a summary
+          level only.
+        - If there are no critical problems, respond with minimal approval
+          (e.g., 'Looks good'). Do not add additional review.
+  auto_review:
+    auto_incremental_review: true
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+knowledge_base:
+  issues:
+    scope: local
+  pull_requests:
+    scope: local


### PR DESCRIPTION
## Summary
- Adds a new `configs/starter` folder with four starter `.coderabbit.yaml` templates: `barebones`, `initial`, `quiet`, and `sample`
- Gives new users a set of ready-to-use starting points for their own CodeRabbit configuration

## Test plan
- [ ] Verify each YAML validates against the CodeRabbit schema
- [ ] Confirm folder placement matches existing `configs/` convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four starter configuration templates: Barebones, Initial, Quiet, and Sample profiles
  * Users can now choose from pre-configured CodeRabbit review behavior templates that control feedback intensity, output verbosity, and reporting features during setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/awesome-coderabbit/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->